### PR TITLE
Add plain.text UTI

### DIFF
--- a/cmd/goneovim/darwin/Contents/Info.plist
+++ b/cmd/goneovim/darwin/Contents/Info.plist
@@ -17,6 +17,14 @@
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.text</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>go</string>


### PR DESCRIPTION
macOS has the concept of Uniform Type Identifiers[1] which allows to associate an app to a bunch of files. This commit asociates Goneovim to all plain text files.

Go doesn't seem to be recognized by the operating system yet so I kept its definition

[1]:https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis