### PR TITLE
Add Macmeta

### DIFF
--- a/editor/config.go
+++ b/editor/config.go
@@ -39,6 +39,7 @@ type editorConfig struct {
 	GinitVim                 string
 	StartFullscreen          bool
 	StartMaximizedWindow     bool
+	Macmeta                  bool
 	Transparent              float64
 	DrawBorder               bool
 	SkipGlobalId             bool

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -650,10 +650,10 @@ func (e *Editor) convertKey(event *gui.QKeyEvent) string {
 
 	// this is macmeta alternatively
 	if runtime.GOOS == "darwin" {
-		if editor.config.Editor.Macmeta {
+		if e.config.Editor.Macmeta {
 			if mod&core.Qt__AltModifier > 0 && mod&core.Qt__ShiftModifier > 0 {
 				text = string(key)
-			} else if mod&core.Qt__AltModifier > 0 && !(mod&core.Qt__ShiftModifier > 0) {
+			} else {
 				text = strings.ToLower(string(key))
 			}
 		}

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -648,6 +648,17 @@ func (e *Editor) convertKey(event *gui.QKeyEvent) string {
 	key := event.Key()
 	mod := event.Modifiers()
 
+	// this is macmeta alternatively
+	if runtime.GOOS == "darwin" {
+		if editor.config.Editor.Macmeta {
+			if mod&core.Qt__AltModifier > 0 && mod&core.Qt__ShiftModifier > 0 {
+				text = string(key)
+			} else if mod&core.Qt__AltModifier > 0 && !(mod&core.Qt__ShiftModifier > 0) {
+				text = strings.ToLower(string(key))
+			}
+		}
+	}
+
 	if mod&core.Qt__KeypadModifier > 0 {
 		switch core.Qt__Key(key) {
 		case core.Qt__Key_Home:

--- a/editor/editor_mac_test.go
+++ b/editor/editor_mac_test.go
@@ -70,6 +70,9 @@ func TestDarwinEditor_convertKey(t *testing.T) {
 	}
 	e := &Editor{}
 	e.InitSpecialKeys()
+	e.config = gonvimConfig{}
+	e.config.Editor.Macmeta = false
+
 	for key, value := range e.specialKeys {
 		tests = append(
 			tests,


### PR DESCRIPTION
This is the equivalent of the `macmeta` configuration in MacVim.
The feature is available by adding the following to `~/.goneovim/setting.toml`

```
[Editor]
Macmeta = true
```

Related issue: #129