### PR TITLE
Separate the built-in markdown preview feature as a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All of the features are optional. You can use it like a plain nvim or as a nvim 
 - Fast (faster than neovim-qt)
 - Cross-platform
 - Modern Text Editor Features
-  - Markdown Preview
+  - Markdown Preview (it is provide as a plugin for goneovim)
   - Minimap
   - Smooth scroll (with MacOS touch pad)
   - Workspace feature which manages multiple nvim


### PR DESCRIPTION
I'm considering separating the built-in markdown preview feature as a plugin.
Here's why

* goneovim's markdown preview uses QtWebEngineProcess. As far as I can research, it is not possible to generate the entire application, including QtWebEngineProcess, as one static binary. I would like to provide a static binary.

* I'm not very good with javascript and haven't been able to improve the markdown preview. I think it's potentially more maintainable to separate it as a plugin than to exist as part of goneovim's huge codebase, and I think it's easier for people who are interested in it to contribute.

I researched how to implement this approach and found a few issue reports that might be helpful.

* https://github.com/therecipe/qt/issues/1120
* https://github.com/therecipe/qt/issues/759