### PR TITLE
use goneovim subdirectory inside XDG_CONFIG_HOME

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -177,7 +177,7 @@ func InitEditor() {
 	if runtime.GOOS != "windows" {
 		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 		if xdgConfigHome != "" {
-			configDir = xdgConfigHome
+			configDir = filepath.Join(xdgConfigHome, "goneovim")
 		} else {
 			configDir = filepath.Join(home, ".config", "goneovim")
 		}


### PR DESCRIPTION
Hi - first of all, thank you for you work on this GUI!

when `$XDG_CONFIG_HOME` is set, `goneovim` currently expects its config file `setting.toml` to be inside `$XDG_CONFIG_HOME`. It should instead follow the convention of having its own subdirectory, and look for a file like `$XDG_CONFIG_HOME/goneovim/setting.toml`.

`$XDG_CONFIG_HOME/setting.toml` (the filepath currently searched for) is too generic to be used by `goneovim`.