### PR TITLE
Ignore errors when creating helptags

### DIFF
--- a/editor/workspace.go
+++ b/editor/workspace.go
@@ -491,7 +491,7 @@ func (w *Workspace) startNvim(path string) error {
 	// Generate goneovim helpdoc tag
 	helpdocpath := getResourcePath() + "/runtime/doc"
 	option = append(option, "--cmd")
-	option = append(option, fmt.Sprintf("helptag %s", helpdocpath))
+	option = append(option, fmt.Sprintf(`try | helptags %s | catch /^Vim\%%((\a\+)\)\=:E/ | endtry`, helpdocpath))
 
 	option = append(option, "--embed")
 


### PR DESCRIPTION
When Goneovim is installed into a non-writable directory, Goneovim is unusable because helptags cannot be written. Ignore errors to make Goneovim usable.

I created this PR without testing locally, as compiling Goneovim takes a lot of time.