### PR TITLE
Accept alternative WSL distribution

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -76,19 +76,19 @@ type Notify struct {
 }
 
 type Options struct {
-	Geometry     string `long:"geometry" description:"Initial window geomtry [e.g. --geometry=800x600]"`
-	Server       string `long:"server" description:"Remote session address [e.g. --server=host:3456]"`
-	Ssh          string `long:"ssh" description:"Attaching to a remote nvim via ssh. Default port is 22. [e.g. --ssh=user@host:port]"`
-	Nvim         string `long:"nvim" description:"Excutable nvim path to attach [e.g. --nvim=/path/to/nvim]"`
-	Debug        string `long:"debug" description:"Run debug mode with debug.log(default) file [e.g. --debug=/path/to/my-debug.log]" optional:"yes" optional-value:"debug.log"`
-	Fullscreen   bool   `long:"fullscreen" description:"Open the window in fullscreen on startup"`
-	Maximized    bool   `long:"maximized" description:"Maximize the window on startup"`
-	Exttabline   bool   `long:"exttabline" description:"Externalize the tabline"`
-	Extcmdline   bool   `long:"extcmdline" description:"Externalize the cmdline"`
-	Extmessages  bool   `long:"extmessages" description:"Externalize the messages. Sets --extcmdline implicitly"`
-	Extpopupmenu bool   `long:"extpopupmenu" description:"Externalize the popupmenu"`
-	Version      bool   `long:"version" description:"Print Goneovim version"`
-	Wsl          bool   `long:"wsl" description:"Attach to nvim process in wsl environment"`
+	Geometry     string  `long:"geometry" description:"Initial window geomtry [e.g. --geometry=800x600]"`
+	Server       string  `long:"server" description:"Remote session address [e.g. --server=host:3456]"`
+	Ssh          string  `long:"ssh" description:"Attaching to a remote nvim via ssh. Default port is 22. [e.g. --ssh=user@host:port]"`
+	Nvim         string  `long:"nvim" description:"Excutable nvim path to attach [e.g. --nvim=/path/to/nvim]"`
+	Debug        string  `long:"debug" description:"Run debug mode with debug.log(default) file [e.g. --debug=/path/to/my-debug.log]" optional:"yes" optional-value:"debug.log"`
+	Fullscreen   bool    `long:"fullscreen" description:"Open the window in fullscreen on startup"`
+	Maximized    bool    `long:"maximized" description:"Maximize the window on startup"`
+	Exttabline   bool    `long:"exttabline" description:"Externalize the tabline"`
+	Extcmdline   bool    `long:"extcmdline" description:"Externalize the cmdline"`
+	Extmessages  bool    `long:"extmessages" description:"Externalize the messages. Sets --extcmdline implicitly"`
+	Extpopupmenu bool    `long:"extpopupmenu" description:"Externalize the popupmenu"`
+	Version      bool    `long:"version" description:"Print Goneovim version"`
+	Wsl          *string `long:"wsl" description:"Attach to nvim process in wsl environment with distribution(default) [e.g. --wsl=Ubuntu]" optional:"yes" optional-value:""`
 }
 
 // Editor is the editor
@@ -833,7 +833,7 @@ func (e *Editor) showWindow() {
 		}
 	}
 
-	if e.opts.Ssh == "" || !e.opts.Wsl {
+	if e.opts.Ssh == "" || e.opts.Wsl == nil {
 		e.window.Show()
 	}
 }

--- a/editor/workspace.go
+++ b/editor/workspace.go
@@ -508,7 +508,7 @@ func (w *Workspace) startNvim(path string) error {
 		// Attaching to /path/to/nvim
 		childProcessCmd := nvim.ChildProcessCommand(editor.opts.Nvim)
 		neovim, err = nvim.NewChildProcess(childProcessArgs, childProcessCmd)
-	} else if editor.opts.Wsl {
+	} else if editor.opts.Wsl != nil {
 		// Attaching remote nvim via wsl
 		w.uiRemoteAttached = true
 		neovim, err = newWslProcess()
@@ -643,6 +643,9 @@ func newWslProcess() (*nvim.Nvim, error) {
 		"$SHELL",
 		"-lic",
 		nvimargs,
+	}
+	if editor.opts.Wsl != nil && *editor.opts.Wsl != "" {
+		wslArgs = append([]string{"-d", *editor.opts.Wsl}, wslArgs...)
 	}
 
 	cmd := exec.CommandContext(

--- a/runtime/doc/goneovim.txt
+++ b/runtime/doc/goneovim.txt
@@ -39,7 +39,7 @@ CLI INTERFACE                                             *goneovim-cli-interfac
           --extmessages   Externalize the messages. Sets --extcmdline implicitly
           --extpopupmenu  Externalize the popupmenu
           --version       Print Goneovim version
-          --wsl           Attach to nvim process in wsl environment
+          --wsl=          Attach to nvim process in wsl environment with distribution(default) [e.g. --wsl=Ubuntu]
     
     Help Options:
       -h, --help          Show this help message


### PR DESCRIPTION
Extended the wsl option to allow specifying a distribution other than the default.
For example, for `Debian`, set `--wsl=Debian`.