### PR TITLE
Run application in the background and support --nofork option

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -89,6 +89,7 @@ type Options struct {
 	Extpopupmenu bool    `long:"extpopupmenu" description:"Externalize the popupmenu"`
 	Version      bool    `long:"version" description:"Print Goneovim version"`
 	Wsl          *string `long:"wsl" description:"Attach to nvim process in wsl environment with distribution(default) [e.g. --wsl=Ubuntu]" optional:"yes" optional-value:""`
+	Nofork       bool    `long:"nofork" description:"Run in foreground"`
 }
 
 // Editor is the editor


### PR DESCRIPTION
Related to #320, detach from terminal by default when Goneovim starts, and leave existing behavior as --nofork option.