### PR TITLE
fix: prevent redundant scheduled release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,9 @@ jobs:
       with:
         fetch-depth: 0
     - run: >
-        test '{ "${{github.event.inputs.tag_name}}" == "nightly"
+        test '{ "${{github.event_name}}" == "schedule"
         && 0 -lt $(git log --oneline --since "yesterday" | wc -l) }
-        || { "${{github.event.inputs.tag_name}}" != "nightly" }'
+        || { "${{github.event_name}}" != "schedule" }'
 
   linux:
     needs: [check-new-commit]


### PR DESCRIPTION
In cron, `workflow_dispatch/inputs/tag_name` is not set to default `nightly`, so use `event_name` instead.

> Run test '{ "" == "nightly" && 0 -lt $(git log --oneline --since "yesterday" | wc -l) } || { "" != "nightly" }'

https://github.com/akiyosi/goneovim/runs/6151160847?check_suite_focus=true