### PR TITLE
Fix new-commit-check condition

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
     - run: >
         test \( "${{github.event_name}}" == "schedule"
-        -a 0 -lt $(git log --oneline --since "yesterday" | wc -l) \)
+        -a 0 -lt $(git log --oneline --since "yesterday" -- . ":!.github" ":!.gitignore" ":!.golangci.yml" | wc -l) \)
         -o \( "${{github.event_name}}" != "schedule" \)
 
   linux:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,9 @@ jobs:
       with:
         fetch-depth: 0
     - run: >
-        test '{ "${{github.event_name}}" == "schedule"
-        && 0 -lt $(git log --oneline --since "yesterday" | wc -l) }
-        || { "${{github.event_name}}" != "schedule" }'
+        test \( "${{github.event_name}}" == "schedule"
+        -a 0 -lt $(git log --oneline --since "yesterday" | wc -l) \)
+        -o \( "${{github.event_name}}" != "schedule" \)
 
   linux:
     needs: [check-new-commit]


### PR DESCRIPTION
The following two have been fixed.
- test command condition
- exclude `.github`, `.gitignore`, `.golangci.yml` when checking commits

This is the result of an action on a time-adjusted commit with `git commit --date='2 days ago'`.
https://github.com/shiena/goneovim/runs/6224173841?check_suite_focus=true
