### PR TITLE
Add support manual font fallback

### DIFF
--- a/editor/config.go
+++ b/editor/config.go
@@ -36,6 +36,7 @@ type editorConfig struct {
 	WindowSeparatorTheme                    string
 	NvimInWsl                               string
 	WSLDist                                 string
+	FontWeight                              string
 	ModeEnablingIME                         []string
 	IndentGuideIgnoreFtList                 []string
 	CharsScaledLineHeight                   []string
@@ -46,8 +47,9 @@ type editorConfig struct {
 	DiffChangePattern                       int
 	CacheSize                               int
 	Linespace                               int
-	Letterspace                             float64
+	Letterspace                             int
 	FontSize                                int
+	FontStretch                             int
 	Margin                                  int
 	Gap                                     int
 	Height                                  int
@@ -78,7 +80,7 @@ type editorConfig struct {
 	BorderlessWindow                        bool
 	RestoreWindowGeometry                   bool
 	ExtCmdline                              bool
-	NoFontMerge                             bool
+	ManualFontFallback                      bool
 	WindowGeometryBasedOnFontmetrics        bool
 	IgnoreFirstMouseClickWhenAppInactivated bool
 	HideTitlebar                            bool
@@ -315,6 +317,10 @@ func (c *gonvimConfig) init() {
 		c.Editor.Margin = 0
 		c.Editor.MouseScrollingUnit = "line"
 	}
+	c.Editor.FontSize = 12
+	c.Editor.FontWeight = "normal"
+	// Horizontal stretch ratio
+	c.Editor.FontStretch = 100
 	c.Editor.FontSize = 12
 	c.Editor.Linespace = 6
 

--- a/editor/imetooltip.go
+++ b/editor/imetooltip.go
@@ -18,33 +18,29 @@ type IMETooltip struct {
 	isShown         bool
 }
 
-func (i *IMETooltip) setQpainterFont(p *gui.QPainter) {
-	if i.font == nil {
-		return
-	}
-	if i.font.fontNew == nil {
-		return
-	}
+// func (i *IMETooltip) setQpainterFont(p *gui.QPainter) {
+// 	if i.font == nil {
+// 		return
+// 	}
+// 	if i.font.qfont == nil {
+// 		return
+// 	}
+//
+// 	p.SetFont(i.getFont())
+// }
 
-	p.SetFont(i.getFont())
-}
-
-func (i *IMETooltip) getFont() *gui.QFont {
+func (i *IMETooltip) getFont() *Font {
 	if i.s.ws.palette != nil && i.s.ws.palette.widget.IsVisible() {
-		font := gui.NewQFont2(editor.extFontFamily, editor.extFontSize, 1, false)
-		font.SetStyleHint(gui.QFont__TypeWriter, gui.QFont__PreferDefault|gui.QFont__ForceIntegerMetrics)
-		font.SetFixedPitch(true)
-		font.SetKerning(false)
-		return font
+		return editor.font
 	} else {
-		return i.font.fontNew
+		return i.font
 	}
 }
 
 func (i *IMETooltip) paint(event *gui.QPaintEvent) {
 	p := gui.NewQPainter2(i)
 
-	i.drawContent(p, i.setQpainterFont)
+	i.drawContent(p, i.getFont)
 
 	p.DestroyQPainter()
 }
@@ -195,21 +191,21 @@ func (i *IMETooltip) parsePreeditString(preeditStr string) {
 
 		if length > 0 {
 			if start > 0 {
-				i.updateText(g, string(r[:start]), i.s.ws.font.letterSpace, i.getFont())
+				i.updateText(g, string(r[:start]), i.s.ws.font.letterSpace, i.getFont().qfont)
 				if start+length < len(r) {
-					i.updateText(h, string(r[start:start+length]), i.s.ws.font.letterSpace, i.getFont())
-					i.updateText(g, string(r[start+length:]), i.s.ws.font.letterSpace, i.getFont())
+					i.updateText(h, string(r[start:start+length]), i.s.ws.font.letterSpace, i.getFont().qfont)
+					i.updateText(g, string(r[start+length:]), i.s.ws.font.letterSpace, i.getFont().qfont)
 				} else {
-					i.updateText(h, string(r[start:]), i.s.ws.font.letterSpace, i.getFont())
+					i.updateText(h, string(r[start:]), i.s.ws.font.letterSpace, i.getFont().qfont)
 				}
 			} else if start == 0 && length < len(r) {
-				i.updateText(h, string(r[0:length]), i.s.ws.font.letterSpace, i.getFont())
-				i.updateText(g, string(r[length:]), i.s.ws.font.letterSpace, i.getFont())
+				i.updateText(h, string(r[0:length]), i.s.ws.font.letterSpace, i.getFont().qfont)
+				i.updateText(g, string(r[length:]), i.s.ws.font.letterSpace, i.getFont().qfont)
 			} else {
-				i.updateText(g, preeditStr, i.s.ws.font.letterSpace, i.getFont())
+				i.updateText(g, preeditStr, i.s.ws.font.letterSpace, i.getFont().qfont)
 			}
 		} else {
-			i.updateText(g, preeditStr, i.s.ws.font.letterSpace, i.getFont())
+			i.updateText(g, preeditStr, i.s.ws.font.letterSpace, i.getFont().qfont)
 		}
 	}
 }

--- a/editor/message.go
+++ b/editor/message.go
@@ -161,7 +161,7 @@ func (m *Message) updateFont() {
 		item.icon.SetFixedSize2(m.ws.font.height, m.ws.font.height)
 		item.label.SetContentsMargins(margin/2, margin, margin, margin)
 		item.icon.Move2(margin*5/4, margin)
-		item.label.SetFont(m.ws.font.fontNew)
+		item.label.SetFont(m.ws.font.qfont)
 	}
 }
 

--- a/editor/minimap.go
+++ b/editor/minimap.go
@@ -85,11 +85,11 @@ func newMiniMap() *MiniMap {
 
 	switch runtime.GOOS {
 	case "windows":
-		m.font = initFontNew("Consolas", 1.0, 0, 0.0)
+		m.font = initFontNew("Consolas", 1.0, gui.QFont__Normal, 100, 0, 0)
 	case "darwin":
-		m.font = initFontNew("Courier New", 2.0, 0, 0.0)
+		m.font = initFontNew("Courier New", 2.0, gui.QFont__Normal, 100, 0, 0)
 	default:
-		m.font = initFontNew("Monospace", 1.0, 0, 0.0)
+		m.font = initFontNew("Monospace", 1.0, gui.QFont__Normal, 100, 0, 0)
 	}
 
 	return m
@@ -677,7 +677,7 @@ func (w *Window) drawMinimap(p *gui.QPainter, y int, col int, cols int) {
 		return
 	}
 	wsfont := w.getFont()
-	p.SetFont(wsfont.fontNew)
+	p.SetFont(wsfont.qfont)
 	p.SetRenderHint(gui.QPainter__Antialiasing, true)
 	line := w.content[y]
 	chars := map[*Highlight][]int{}

--- a/editor/popupmenu.go
+++ b/editor/popupmenu.go
@@ -159,13 +159,13 @@ func (p *PopupMenu) updateFont(font *Font) {
 		return
 	}
 
-	p.detailLabel.SetFont(font.fontNew)
+	p.detailLabel.SetFont(font.qfont)
 	for i := 0; i < p.total; i++ {
 		popupItem := p.items[i]
-		popupItem.wordLabel.SetFont(font.fontNew)
-		popupItem.digitLabel.SetFont(font.fontNew)
-		popupItem.menuLabel.SetFont(font.fontNew)
-		popupItem.infoLabel.SetFont(font.fontNew)
+		popupItem.wordLabel.SetFont(font.qfont)
+		popupItem.digitLabel.SetFont(font.qfont)
+		popupItem.menuLabel.SetFont(font.qfont)
+		popupItem.infoLabel.SetFont(font.qfont)
 		popupItem.kindIcon.SetFixedSize2(editor.iconSize, editor.iconSize)
 		margin := editor.config.Editor.Linespace/2 + 2
 		popupItem.kindwidget.SetFixedWidth(editor.iconSize + margin*2)

--- a/editor/tabline.go
+++ b/editor/tabline.go
@@ -255,7 +255,7 @@ func (t *Tabline) updateFont() {
 		return
 	}
 
-	t.font = t.ws.font.fontNew
+	t.font = t.ws.font.qfont
 
 	// t.widget.SetFont(t.font)
 	for _, tab := range t.Tabs {

--- a/editor/tooltip.go
+++ b/editor/tooltip.go
@@ -18,18 +18,34 @@ type ColorStr struct {
 type Tooltip struct {
 	widgets.QWidget
 
-	s          *Screen
-	text       []*ColorStr
-	font       *Font
-	widthSlice []float64
+	s             *Screen
+	text          []*ColorStr
+	font          *Font
+	fallbackfonts []*Font
+	widthSlice    []float64
 }
 
-func (t *Tooltip) drawContent(p *gui.QPainter, setFont func(*gui.QPainter)) {
-	setFont(p)
-	font := p.Font()
+func resolveMetricsInFontFallback(font *Font, fallbackfonts []*Font, char string) float64 {
+	if len(fallbackfonts) == 0 {
+		return font.fontMetrics.HorizontalAdvance(char, -1)
+	}
 
-	p.SetPen2(t.s.ws.foreground.QColor())
+	hasGlyph := font.hasGlyph(char)
+	if hasGlyph {
+		return font.fontMetrics.HorizontalAdvance(char, -1)
+	} else {
+		for _, ff := range fallbackfonts {
+			hasGlyph = ff.hasGlyph(char)
+			if hasGlyph {
+				return ff.fontMetrics.HorizontalAdvance(char, -1)
+			}
+		}
+	}
 
+	return font.fontMetrics.HorizontalAdvance(char, -1)
+}
+
+func (t *Tooltip) drawContent(p *gui.QPainter, getFont func() *Font) {
 	if t.text == nil {
 		return
 	}
@@ -58,6 +74,10 @@ func (t *Tooltip) drawContent(p *gui.QPainter, setFont func(*gui.QPainter)) {
 
 		r := []rune(chunk.str)
 		for _, rr := range r {
+			// setFont(p)
+			p.SetFont(resolveFontFallback(getFont(), t.fallbackfonts, string(rr)).qfont)
+			font := p.Font()
+
 			// draw background
 			p.FillRect4(
 				core.NewQRectF4(
@@ -108,14 +128,14 @@ func (t *Tooltip) drawContent(p *gui.QPainter, setFont func(*gui.QPainter)) {
 	}
 }
 
-func (t *Tooltip) setQpainterFont(p *gui.QPainter) {
-	p.SetFont(t.font.fontNew)
+func (t *Tooltip) getFont() *Font {
+	return t.font
 }
 
 func (t *Tooltip) paint(event *gui.QPaintEvent) {
 	p := gui.NewQPainter2(t)
 
-	t.drawContent(p, t.setQpainterFont)
+	t.drawContent(p, t.getFont)
 
 	p.DestroyQPainter()
 }
@@ -133,13 +153,13 @@ func (t *Tooltip) clearText() {
 	t.text = newText
 }
 
-func (t *Tooltip) updateText(hl *Highlight, str string, letterspace float64, font *gui.QFont) {
+func (t *Tooltip) updateText(hl *Highlight, str string, letterspace int, font *gui.QFont) {
 	if t.font == nil {
 		return
 	}
 
 	fontMetrics := gui.NewQFontMetricsF(font)
-	cellwidth := fontMetrics.HorizontalAdvance("w", -1) + letterspace
+	cellwidth := fontMetrics.HorizontalAdvance("w", -1) + float64(letterspace)
 
 	// rune text
 	r := []rune(str)
@@ -151,7 +171,8 @@ func (t *Tooltip) updateText(hl *Highlight, str string, letterspace float64, fon
 		// detect char width based cell width
 		w := cellwidth
 		for {
-			cwidth := fontMetrics.HorizontalAdvance(string(rr), -1)
+			// cwidth := fontMetrics.HorizontalAdvance(string(rr), -1)
+			cwidth := resolveMetricsInFontFallback(t.font, t.fallbackfonts, string(rr))
 			if cwidth <= w {
 				break
 			}

--- a/runtime/doc/goneovim.txt
+++ b/runtime/doc/goneovim.txt
@@ -244,7 +244,7 @@ COMMANDS                                                       *goneovim-command
 	in settings.toml, or if you want to put the settings in |init.vim|, 
 	you can use the following |rpcnotify|.
 >
-	:call rpcnotify(0, "Gui", "gonvim_letter_spacing", 0.5)
+	:call rpcnotify(0, "Gui", "gonvim_letter_spacing", 2)
 <
 
 :GuiMacmeta {boolean}                                               *:GuiMacmeta*
@@ -405,6 +405,23 @@ All Options are follows:
         # FontFamily = "Windows"
         ## Fontsize is
         # FontSize = 12
+        ## FontWeight specifis the glyph weight for the configured font family.
+        ## * Possible values are: 
+        ##    - "Thin", "Hairline"
+        ##    - "ExtraLight", "Ultralight"
+        ##    - "Light"
+        ##    - "Normal", "regular"
+        ##    - "Medium"
+        ##    - "DemiBold", "SemiBold"
+        ##    - "Bold"
+        ##    - "Extra Bold", "UltraBold"
+        ##    - "Black"
+        ## * Default value is "Normal".
+        ## * Note that for the glyphs of a specified weight to be validly displayed,
+        ##   a font of the corresponding weight must be installed.
+        # FontWeight = "normal"
+        ## FontStretch is the ratio of Horizontal stretch. Default is 100 [%]
+        # FontStretch = 100
         ## letterspace is
         # Letterspace = 0
         


### PR DESCRIPTION
This PR allows font fallback on a per character basis rather than per font-family basis.
This feature is enabled by the following settings

```
[Editor]
#...
ManualFontFallback = true
```