### PR TITLE
Convert Windows paths to WSL paths when running under WSL

### DIFF
--- a/editor/window.go
+++ b/editor/window.go
@@ -3515,12 +3515,14 @@ func (w *Window) focusGrid() {
 	}
 }
 
-// convertWindowsToUnixPath converts a Windows path to a Unix path as WSL does.
-func convertWindowsToUnixPath(winPath string) string {
-	// Replace backslashes with forward slashes
+// convertWindowsToUnixPath converts a Windows path to a Unix path as wslpath does.
+func convertWindowsToUnixPath(winPath string) string {	
 	unixPath := strings.ReplaceAll(winPath, `\`, `/`)
+	if len(unixPath) <= 2 {
+		return unixPath
+	}
 	// Convert drive letter to /mnt/<drive-letter>
-	if len(unixPath) > 1 && unixPath[1] == ':' {
+	if unixPath[1] == ':' {
 		driveLetter := strings.ToLower(string(unixPath[0]))
 		unixPath = fmt.Sprintf("/mnt/%s%s", driveLetter, unixPath[2:])
 	}

--- a/editor/window.go
+++ b/editor/window.go
@@ -3473,6 +3473,11 @@ func (w *Window) dropEvent(e *gui.QDropEvent) {
 					}
 				}
 
+				// Check if running under WSL and convert path if necessary
+				if editor.opts.Wsl != nil {
+                    filepath = convertWindowsToUnixPath(filepath)
+                }
+
 				// if message grid is active and drop the file in message area,
 				// then, we put the filepath string into message area.
 				if w.isMsgGrid && w.s.ws.cursor.gridid == w.grid {
@@ -3508,6 +3513,18 @@ func (w *Window) focusGrid() {
 		case <-time.After(NVIMCALLTIMEOUT * time.Millisecond):
 		}
 	}
+}
+
+// convertWindowsToUnixPath converts a Windows path to a Unix path as WSL does.
+func convertWindowsToUnixPath(winPath string) string {
+    // Replace backslashes with forward slashes
+    unixPath := strings.ReplaceAll(winPath, `\`, `/`)
+    // Convert drive letter to /mnt/<drive-letter>
+    if len(unixPath) > 1 && unixPath[1] == ':' {
+        driveLetter := strings.ToLower(string(unixPath[0]))
+        unixPath = fmt.Sprintf("/mnt/%s%s", driveLetter, unixPath[2:])
+    }
+    return unixPath
 }
 
 func (w *Window) isShown() bool {

--- a/editor/window.go
+++ b/editor/window.go
@@ -3475,8 +3475,8 @@ func (w *Window) dropEvent(e *gui.QDropEvent) {
 
 				// Check if running under WSL and convert path if necessary
 				if editor.opts.Wsl != nil {
-                    filepath = convertWindowsToUnixPath(filepath)
-                }
+					filepath = convertWindowsToUnixPath(filepath)
+				}
 
 				// if message grid is active and drop the file in message area,
 				// then, we put the filepath string into message area.
@@ -3517,14 +3517,14 @@ func (w *Window) focusGrid() {
 
 // convertWindowsToUnixPath converts a Windows path to a Unix path as WSL does.
 func convertWindowsToUnixPath(winPath string) string {
-    // Replace backslashes with forward slashes
-    unixPath := strings.ReplaceAll(winPath, `\`, `/`)
-    // Convert drive letter to /mnt/<drive-letter>
-    if len(unixPath) > 1 && unixPath[1] == ':' {
-        driveLetter := strings.ToLower(string(unixPath[0]))
-        unixPath = fmt.Sprintf("/mnt/%s%s", driveLetter, unixPath[2:])
-    }
-    return unixPath
+	// Replace backslashes with forward slashes
+	unixPath := strings.ReplaceAll(winPath, `\`, `/`)
+	// Convert drive letter to /mnt/<drive-letter>
+	if len(unixPath) > 1 && unixPath[1] == ':' {
+		driveLetter := strings.ToLower(string(unixPath[0]))
+		unixPath = fmt.Sprintf("/mnt/%s%s", driveLetter, unixPath[2:])
+	}
+	return unixPath
 }
 
 func (w *Window) isShown() bool {


### PR DESCRIPTION
This pull request includes a commit that adds functionality to convert Windows paths to Unix paths when running under Windows Subsystem for Linux (WSL). This is achieved by replacing backslashes with forward slashes and converting the drive letter to the corresponding `/mnt/<drive-letter>` format. This enhancement ensures that file paths are correctly handled when running the software under WSL.

fixes  #548