### PR TITLE
Add Hyper_L/R to the list of non-input keys

### DIFF
--- a/editor/input.go
+++ b/editor/input.go
@@ -244,6 +244,8 @@ func (e *Editor) convertKey(event *gui.QKeyEvent) string {
 			key == int(core.Qt__Key_Control) ||
 			key == int(core.Qt__Key_Meta) ||
 			key == int(core.Qt__Key_Shift) ||
+			key == int(core.Qt__Key_Hyper_L) ||
+			key == int(core.Qt__Key_Hyper_R) ||
 			key == int(core.Qt__Key_Super_L) ||
 			key == int(core.Qt__Key_Super_R) {
 			return ""


### PR DESCRIPTION
The current list of modifiers keys inside editor/input.go doesn't handle the keys Hyper_L or Hyper_R, typically mapped to Linux window manager actions. As now, at least on a Debian 12 with DWM setup, it insert a � character. This commit add the Hyper_L and Hyper_R keys to the list to avoid this behaviour: this is only made possible by the fact that the akiyosi's version of Qt bindings add these modifiers.