### PR TITLE
[WIP] Proportional fonts support

### DIFF
--- a/editor/config.go
+++ b/editor/config.go
@@ -89,6 +89,7 @@ type editorConfig struct {
 	IgnoreSaveConfirmationWithCloseButton   bool
 	UseWSL                                  bool
 	ShowDiffDialogOnDrop                    bool
+	ProportionalFontAlignGutter             bool
 }
 
 type cursorConfig struct {

--- a/editor/cursor.go
+++ b/editor/cursor.go
@@ -505,12 +505,13 @@ func (c *Cursor) updateCursorShape(win *Window) {
 		}
 	case "vertical":
 		c.isTextDraw = true
-		if (c.font == nil || !c.font.proportional) {
+		c.horizontalShift = 0
+		font := win.font
+		if font == nil || !font.proportional {
 			width = int(math.Ceil(float64(width) * p))
 		} else {
-			width = int(c.font.cellwidth) / 10
+			width = int(font.cellwidth) / 10
 		}
-		c.horizontalShift = 0
 	default:
 		c.isTextDraw = true
 		c.horizontalShift = 0

--- a/editor/cursor.go
+++ b/editor/cursor.go
@@ -585,23 +585,7 @@ func (c *Cursor) updateCursorPos(row, col int, win *Window) {
 	if !c.font.proportional {
 		x += float64(col)*font.cellwidth
 	} else {
-		// For proportional fonts, compute the length of each char
-		var fm *gui.QFontMetricsF
-		for i := 0; i < c.col; i++ {
-			cell := win.content[c.row][i]
-			if !cell.highlight.italic && !cell.highlight.bold {
-				fm = c.font.fontMetrics
-			} else if !cell.highlight.bold {
-				fm = c.font.italicFontMetrics
-			} else if !cell.highlight.italic {
-				fm = c.font.boldFontMetrics
-			} else {
-				fm = c.font.italicBoldFontMetrics
-			}
-			// TODO: Use cache to avoid calling HorizontalAdvance?
-			// (Window.xPixelsIndexes may not be initialized.)
-			x += fm.HorizontalAdvance(cell.char, -1)
-		}
+		x += win.getSinglePixelX(c.row, c.col)
 	}
 
 	y := float64(winy + int(float64(row*font.lineHeight)+float64(verScrollPixels)))

--- a/editor/cursor.go
+++ b/editor/cursor.go
@@ -106,7 +106,9 @@ func (c *Cursor) paintEvent(event *gui.QPaintEvent) {
 		c.devicePixelRatio = float64(p.PaintEngine().PaintDevice().DevicePixelRatio())
 	}
 
-	if c.sourcetext == "" || c.devicePixelRatio == 0 || c.width < int(font.cellwidth/2.0) {
+	// Fixed font aren't draw if cursor isn't wide enough.
+	// But for proportional, it would ends not drawing "i","t","!"...
+	if c.sourcetext == "" || c.devicePixelRatio == 0 || (c.width < int(font.cellwidth/2.0) && !c.font.proportional) {
 		p.DestroyQPainter()
 		return
 	}
@@ -372,7 +374,7 @@ func (c *Cursor) updateFont(targetWin *Window, font *Font, fallbackfonts []*Font
 	}
 }
 
-func (c *Cursor) updateCursorShape() {
+func (c *Cursor) updateCursorShape(win *Window) {
 	if !c.ws.cursorStyleEnabled {
 		return
 	}
@@ -461,8 +463,16 @@ func (c *Cursor) updateCursorShape() {
 	var cellwidth float64
 	var height, lineSpace int
 
+
 	if c.font != nil {
-		cellwidth = c.font.cellwidth
+		if !c.font.proportional {
+			cellwidth = c.font.cellwidth
+		} else {
+			fm := c.font.fontMetrics
+			char := win.content[c.row][c.col].char
+			cellwidth = fm.HorizontalAdvance(char, -1)
+		}
+
 		height = c.font.height
 		lineSpace = c.font.lineSpace
 		if lineSpace < 0 {
@@ -478,7 +488,7 @@ func (c *Cursor) updateCursorShape() {
 		}
 	}
 	width := int(math.Trunc(cellwidth))
-	if !c.normalWidth {
+	if !c.normalWidth && (c.font == nil || !c.font.proportional) {
 		width = width * 2
 	}
 
@@ -495,7 +505,11 @@ func (c *Cursor) updateCursorShape() {
 		}
 	case "vertical":
 		c.isTextDraw = true
-		width = int(math.Ceil(float64(width) * p))
+		if (c.font == nil || !c.font.proportional) {
+			width = int(math.Ceil(float64(width) * p))
+		} else {
+			width = int(c.font.cellwidth) / 10
+		}
 		c.horizontalShift = 0
 	default:
 		c.isTextDraw = true
@@ -567,7 +581,29 @@ func (c *Cursor) updateCursorPos(row, col int, win *Window) {
 		horScrollPixels += win.scrollPixels[0]
 	}
 
-	x := float64(winx + int(float64(col)*font.cellwidth) + horScrollPixels)
+	var x float64 = float64(winx + horScrollPixels)
+	if !c.font.proportional {
+		x += float64(col)*font.cellwidth
+	} else {
+		// For proportional fonts, compute the length of each char
+		var fm *gui.QFontMetricsF
+		for i := 0; i < c.col; i++ {
+			cell := win.content[c.row][i]
+			if !cell.highlight.italic && !cell.highlight.bold {
+				fm = c.font.fontMetrics
+			} else if !cell.highlight.bold {
+				fm = c.font.italicFontMetrics
+			} else if !cell.highlight.italic {
+				fm = c.font.boldFontMetrics
+			} else {
+				fm = c.font.italicBoldFontMetrics
+			}
+			// TODO: Use cache to avoid calling HorizontalAdvance?
+			// (Window.xPixelsIndexes may not be initialized.)
+			x += fm.HorizontalAdvance(cell.char, -1)
+		}
+	}
+
 	y := float64(winy + int(float64(row*font.lineHeight)+float64(verScrollPixels)))
 	if font.lineSpace > 0 {
 		y += float64(font.lineSpace) / 2.0
@@ -660,7 +696,7 @@ func (c *Cursor) update() {
 	c.updateCursorText(row, col, win)
 
 	// update cursor shape
-	c.updateCursorShape()
+	c.updateCursorShape(win)
 
 	// if ext_cmdline is true
 	if c.ws.cmdline != nil {

--- a/editor/nvim.go
+++ b/editor/nvim.go
@@ -475,6 +475,7 @@ func setupGoneovimCommands(neovim *nvim.Nvim) {
 	}
 	gonvimCommands = gonvimCommands + `
 	command! -nargs=1 GonvimGridFont call rpcnotify(g:goneovim_channel_id, "Gui", "gonvim_grid_font", <args>)
+	command! -nargs=1 GonvimGridFontAutomaticHeight call rpcnotify(g:goneovim_channel_id, "Gui", "gonvim_grid_font_automatic_height", <args>)
 	command! -nargs=1 GonvimLetterSpacing call rpcnotify(g:goneovim_channel_id, "Gui", "gonvim_letter_spacing", <args>)
 	command! -nargs=1 GuiMacmeta call rpcnotify(g:goneovim_channel_id, "Gui", "gonvim_macmeta", <args>)
 	command! -nargs=? GonvimMaximize call rpcnotify(g:goneovim_channel_id, "Gui", "gonvim_maximize", <args>)

--- a/editor/screen.go
+++ b/editor/screen.go
@@ -341,6 +341,100 @@ func (s *Screen) gridFont(update interface{}) {
 	}
 }
 
+/* Based on `gridFont`, this function compute the height of the selected
+ * font to keep the same number of row in the window. Thus, it avoids issues
+ * while resizing (especially with status line).
+ *
+ * NOTE: Vertical splitting after using this function will leads to very
+ *       weird behaviour, and should be avoided.
+ */
+func (s *Screen) gridFontAutomaticHeight(update interface{}) {
+
+	// Get current window
+	grid := s.ws.cursor.gridid
+	if !editor.config.Editor.ExtCmdline {
+		grid = s.ws.cursor.bufferGridid
+	}
+
+	win, ok := s.getWindow(grid)
+	if !ok {
+		return
+	}
+
+	// The function parameter is the font family
+	fontFamily, ok := update.(string)
+	if !ok {
+		return
+	}
+	if fontFamily == "" {
+		return
+	}
+
+	font := win.getFont()
+
+	// The font height we'll try to approximate with the new font
+	oldFontHeight := font.fontMetrics.Height()
+
+	// Create the font
+	f := gui.NewQFont()
+	f.SetFamily(fontFamily)
+	f.SetFixedPitch(false)
+	f.SetKerning(false)
+
+	// The values we'll Iteratively modify
+	var newFontHeight float64
+	var newFontSize float64
+
+	// Create the font metrics and initialize a font size
+	newFontSize = font.size
+	f.SetPointSizeF(newFontSize)
+	fm := gui.NewQFontMetricsF(f)
+	newFontHeight = fm.Height()
+
+	// Function to update the font size
+	updateFont := func (u float64) {
+		newFontSize += u
+		f.SetPointSizeF(newFontSize)
+		fm := gui.NewQFontMetricsF(f)
+		newFontHeight = fm.Height()
+	}
+
+	// Iteratively change the font size until the right height is reached
+	for newFontHeight < oldFontHeight {
+		updateFont(1)
+	}
+	for newFontHeight > oldFontHeight {
+		updateFont(-1)
+	}
+	for newFontHeight < oldFontHeight {
+		updateFont(0.1)
+	}
+	for newFontHeight > oldFontHeight {
+		updateFont(-0.1)
+	}
+
+	// Build the new font
+	win.font = initFontNew(fontFamily, newFontSize, font.weight, font.stretch, font.lineSpace, font.letterSpace)
+	if win.font == nil {
+		return
+	}
+	s.ws.cursor.font = win.font
+	win.fallbackfonts = nil
+	s.ws.cursor.fallbackfonts = win.fallbackfonts
+
+	// Cache
+	cache := win.cache
+	if cache == (Cache{}) {
+		cache := newCache()
+		win.cache = cache
+	} else {
+		win.paintMutex.Lock()
+		win.cache.purge()
+		win.paintMutex.Unlock()
+	}
+
+}
+
 func (s *Screen) purgeTextCacheForWins() {
 	if !editor.config.Editor.CachedDrawing {
 		return

--- a/editor/window.go
+++ b/editor/window.go
@@ -2672,7 +2672,7 @@ func (w *Window) drawText(p *gui.QPainter, y int, col int, cols int) {
 					if buffer.Len() != 0 {
 						w.drawTextInPos(
 							p,
-							int(float64(x-pos)*wsfont.cellwidth)+horScrollPixels,
+							int(w.getPixelX(wsfont, y, x-pos))+horScrollPixels,
 							wsfontLineHeight+verScrollPixels,
 							buffer.String(),
 							hlkey,

--- a/editor/workspace.go
+++ b/editor/workspace.go
@@ -1938,6 +1938,8 @@ func (ws *Workspace) handleGui(updates []interface{}) {
 		ws.letterSpacing(updates[1])
 	case "gonvim_grid_font":
 		ws.screen.gridFont(updates[1])
+	case "gonvim_grid_font_automatic_height":
+		ws.screen.gridFontAutomaticHeight(updates[1])
 	case "gonvim_macmeta":
 		ws.handleMacmeta(updates[1])
 	case "gonvim_minimap_update":


### PR DESCRIPTION
This work-in-progress attempt to add support for proportional (i.e. non-monospace) fonts, as discussed in #127.

## Motivation

As a terminal application, Vim/Neovim have no support for non-monospace fonts, while many Graphical editors have: Emacs, VS Code, and many others. This is limiting the use of Neovim for non-programming (prose) writing practices, despite its value for such stuff: academic texts[^1],  novels, poetry [^3]  --whatever writing task that requires not so much to write text but to "rewrite and edit[^2]" it--, or everyday tasks such as mail, personal notes... 
For prose, proportional fonts have strong benefits (easier to read, especially for long texts), but [even for code](https://storck.io/posts/proportional-programming-code-fonts/), some people argue that proportional fonts are worth to use (see the [Go Fonts](https://go.dev/blog/go-fonts)).

The design of Goneovim seems to make possible the use of proportional fonts for Neovim. It would be great, since there is no GUI that support that feature (Neovide, Neovim-Qt, Fvim, Uivonim...).

[^1]: There is a lot of plugins and tools to use (Neo)Vim with [Pandoc](https://github.com/vim-pandoc/vim-pandoc), or [Bib(La)TeX](https://github.com/ferdinandyb/bibtexcite.vim), or [Zotero](https://github.com/jalvesaq/zotcite).

[^2]: Howard Becker, [Writing for Social Scientists](https://atgender.eu/wp-content/uploads/sites/207/2022/03/Howard-S.-Becker-Writing-for-Social-Scientists_-How-to-Start-and-Finish-Your-Thesis-Book-or-Article_-Second-Edition-University-Of-Chicago-Press-2007.pdf).

[^3]: There are many blog posts stating that (Neo)Vim is a good prose editor. See, e.g.:  https://jonathanh.co.uk/blog/writing-prose-in-vim/ or https://discover.hubpages.com/technology/how-and-why-i-use-vim-for-prose-writing or https://jamierubin.net/2019/03/21/writing-with-vim/

## Current Progress

- Text, background and decoration rendering.
- Cursor position, text, background and shape.
- Align the Line Number column end, to align the beginning of the buffer lines.
- Left align buffer content (independantly of gutter/signcolumn content).
- Possibility to use both proportional fonts for some grids and monospace for others.

![victor-burgin](https://github.com/user-attachments/assets/cbb1c3cb-415a-4142-b6a1-b6c54afb8cdd)

<!--
(Left: without the current PR changes / Right: with these changes.)

![2](https://github.com/user-attachments/assets/df468f16-051b-4468-9bc6-a683eadb5707)

![1](https://github.com/user-attachments/assets/da0d3ef7-4e4e-47b1-b087-b6b3d5166ed6)
-->

## Things to be Fixed

- Floating windows borders.
- Floating window position (completion / LSP).
- CPU usage.
- Autocommands such as `autocmd BufEnter *.md :GonvimGridFontAutomaticHeight "Liberation Sans"`.
- Completion window position at the right place (near cursor).
- Some punctuation having incorrect width depending on the context:

![brackets](https://github.com/user-attachments/assets/6dc8e509-34c1-46ed-930f-3d388bf5f959)
![parentheses](https://github.com/user-attachments/assets/b2207abe-3ed0-42cc-ba3b-ff35b04795f3)
![ampersand](https://github.com/user-attachments/assets/75a59f7f-7e40-46c1-8673-6acf4d6eab67)

## Current Limitation: Visual Wrap

The linebreak (visual wrap) is done, as now, by Neovim (using optiong `linebreak`) and not by Goneovim. Thus the linebreak happens *long before* the horizontal end (right) of the window (see screenshot), because it's based on the widest character (italic `W`). There are many options here. Goneovim could manage by itself the wrapping, but I don't know how much work it would require, and how it could impact performance.
On the other hand, as the screenshot shows, when writing prose, line usually tends to have no extreme widths: neither as narrow as lines fulls of `i`, nor as wide as lines full of uppercased italic `W`. Width seems not to vary so much. Thus, the size of the window could be based on the length of a letter narrower than `W`, e.g. `u`. (But I don't know what to do / how to handle special cases, when line is too long.) At the same time, line break long before the horizontal limit of the window may not be an issue at all for some users, as short lines (~10 words) as usually considered easier to read than long lines.

![visual-wrap](https://github.com/user-attachments/assets/0c358b4d-9f2e-4151-b244-769b81e855ed)

## Configuration Requirements

It's currently required to set some configuration variable in order to use proportional fonts:

- `DisableLigatures` must be set to `false`, because if set to `true` it will trigger the cell-based rendering. There's probably no reason to change this.
- `LetterSpace` must be set to `0` for the same reason.

## Changes and Implementation

The changes must not impact performances of Goneovim for non-monospace fonts. Thus, every change is wrapped inside a conditional `if !ont.proportional`. (There may be a small impact because of these tests, but it may not be significant.) These changes use the new `proportional` field, added to the `Font` structure. There are three more fields added to this structure, all of them about `QFontMetrics`: `italicFontMetrics`, `boldFontMetrics`, `italicBoldFontMetrics`. That's because in proportional fonts, each character for each font variant has a specific width. Thus, the existing field `italicWidth` or a new field `italicWidthScale` couldn't be used to compute the width of italic/bold characters. 
The structure `Window` also have a new field, also unused when monospace fonts are used: `xPixelsIndexes`. It's used to store the position, in X-axis, of each character for the lines currently drawn. It's useful to avoid hundreds of calls to `QFontMetrics.HorizontalAdvance(char, ...)`.
