### PR TITLE
fix: avoid crash caused by GonvimResize argument

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -1103,11 +1103,18 @@ func (e *Editor) setWindowSizeFromOpts() {
 func (e *Editor) setWindowSize(s string) (int, int) {
 	var width, height int
 	var err error
-	width, err = strconv.Atoi(strings.SplitN(s, "x", 2)[0])
+
+	parsed_s := strings.SplitN(s, "x", 2)
+	if len(parsed_s) != 2 {
+		// TODO: Error message to user?
+		return 40, 30
+	}
+
+	width, err = strconv.Atoi(parsed_s[0])
 	if err != nil || width < 40 {
 		width = 40
 	}
-	height, err = strconv.Atoi(strings.SplitN(s, "x", 2)[1])
+	height, err = strconv.Atoi(parsed_s[1])
 	if err != nil || height < 30 {
 		height = 30
 	}

--- a/editor/workspace.go
+++ b/editor/workspace.go
@@ -1825,8 +1825,11 @@ func (ws *Workspace) handleGui(updates []interface{}) {
 		go setupGoneovimClipBoard(ws.nvim)
 	case "gonvim_uienter":
 	case "gonvim_resize":
-		width, height := editor.setWindowSize(updates[1].(string))
-		editor.window.Resize2(width, height)
+		arg, ok := updates[1].(string)
+		if ok {
+			width, height := editor.setWindowSize(arg)
+			editor.window.Resize2(width, height)
+		}
 	case "gonvim_fullscreen":
 		arg := 1
 		if len(updates) == 2 {


### PR DESCRIPTION
__Problem__:

Goneovim crashes if `:GonvimResize` argument is either of wrong type (e.g. `int64` instead of `string`) or not well formed, as mentioned in #592. Therefore, these commands will leads to a crash:

```vim
:GonvimResize 1
:GonvimResize ""
```

__Solution__:

Add checks before and while executing the Go function associated to `:GonvimResize`:
- ensure that the argument is a string;
- ensure that this string is successfully parsed.
