### PR TITLE
Add customization of native title bar colors on Windows 11

### DIFF
--- a/editor/config.go
+++ b/editor/config.go
@@ -89,6 +89,8 @@ type editorConfig struct {
 	IgnoreSaveConfirmationWithCloseButton   bool
 	UseWSL                                  bool
 	ShowDiffDialogOnDrop                    bool
+	NativeTitleBarBackgroundColor                    string
+	NativeTitleBarTextColor                          string
 }
 
 type cursorConfig struct {
@@ -365,6 +367,9 @@ func (c *gonvimConfig) init() {
 
 	c.Editor.DesktopNotifications = false
 	c.Editor.ClickEffect = false
+
+	c.Editor.NativeTitleBarBackgroundColor = ""
+	c.Editor.NativeTitleBarTextColor = ""
 
 	// replace diff color drawing pattern
 	c.Editor.DiffAddPattern = 1

--- a/editor/config.go
+++ b/editor/config.go
@@ -89,8 +89,8 @@ type editorConfig struct {
 	IgnoreSaveConfirmationWithCloseButton   bool
 	UseWSL                                  bool
 	ShowDiffDialogOnDrop                    bool
-	NativeTitleBarBackgroundColor                    string
-	NativeTitleBarTextColor                          string
+	NativeTitlebarBackgroundColor                    string
+	NativeTitlebarTextColor                          string
 }
 
 type cursorConfig struct {
@@ -368,8 +368,8 @@ func (c *gonvimConfig) init() {
 	c.Editor.DesktopNotifications = false
 	c.Editor.ClickEffect = false
 
-	c.Editor.NativeTitleBarBackgroundColor = ""
-	c.Editor.NativeTitleBarTextColor = ""
+	c.Editor.NativeTitlebarBackgroundColor = ""
+	c.Editor.NativeTitlebarTextColor = ""
 
 	// replace diff color drawing pattern
 	c.Editor.DiffAddPattern = 1

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -301,7 +301,7 @@ func InitEditor(options Options, args []string) {
 	e.window.Show()
 
 	// Apply native title bar customization
-	e.applyNativeTitleBarCustomization()
+	e.applyNativeTitlebarCustomization()
 
 	// window layout
 	e.setWindowLayout()
@@ -1059,13 +1059,13 @@ func (e *Editor) updateGUIColor() {
 	e.putLog("finished updating GUI color")
 }
 
-func (e *Editor) applyNativeTitleBarCustomization() {
-	if e.config.Editor.NativeTitleBarBackgroundColor != "" {
-		setNativeTitleBarColor(e.window, e.config.Editor.NativeTitleBarBackgroundColor)
+func (e *Editor) applyNativeTitlebarCustomization() {
+	if e.config.Editor.NativeTitlebarBackgroundColor != "" {
+		setNativeTitlebarColor(e.window, e.config.Editor.NativeTitlebarBackgroundColor)
 	}
 
-	if e.config.Editor.NativeTitleBarTextColor != "" {
-		setNativeTitleTextColor(e.window, e.config.Editor.NativeTitleBarTextColor)
+	if e.config.Editor.NativeTitlebarTextColor != "" {
+		setNativeTitleTextColor(e.window, e.config.Editor.NativeTitlebarTextColor)
 	}
 }
 

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -300,6 +300,9 @@ func InitEditor(options Options, args []string) {
 	isSetWindowState := e.initAppWindow()
 	e.window.Show()
 
+	// Apply native title bar customization
+	e.applyNativeTitleBarCustomization()
+
 	// window layout
 	e.setWindowLayout()
 
@@ -1054,6 +1057,16 @@ func (e *Editor) updateGUIColor() {
 
 	// e.window.SetWindowOpacity(1.0)
 	e.putLog("finished updating GUI color")
+}
+
+func (e *Editor) applyNativeTitleBarCustomization() {
+	if e.config.Editor.NativeTitleBarBackgroundColor != "" {
+		setNativeTitleBarColor(e.window, e.config.Editor.NativeTitleBarBackgroundColor)
+	}
+
+	if e.config.Editor.NativeTitleBarTextColor != "" {
+		setNativeTitleTextColor(e.window, e.config.Editor.NativeTitleBarTextColor)
+	}
 }
 
 func hexToRGBA(hex string) *RGBA {

--- a/editor/editor_darwin.go
+++ b/editor/editor_darwin.go
@@ -6,8 +6,8 @@ package editor
 #include "objcbridge.h"
 #include <stdlib.h>
 */
+import "C"
 import (
-	"C"
 	"unsafe"
 
 	frameless "github.com/akiyosi/goqtframelesswindow"

--- a/editor/editor_darwin.go
+++ b/editor/editor_darwin.go
@@ -6,8 +6,12 @@ package editor
 #include "objcbridge.h"
 #include <stdlib.h>
 */
-import "C"
-import "unsafe"
+import (
+	"C"
+	"unsafe"
+
+	frameless "github.com/akiyosi/goqtframelesswindow"
+)
 
 //export GetOpeningFilepath
 func GetOpeningFilepath(str *C.char) {
@@ -22,4 +26,14 @@ func GetOpeningFilepath(str *C.char) {
 
 func setMyApplicationDelegate() {
 	C.SetMyApplicationDelegate()
+}
+
+func setNativeTitleBarColor(window *frameless.QFramelessWindow, colorStr string) error {
+	// Not implemented (yet)
+	return nil
+}
+
+func setNativeTitleTextColor(window *frameless.QFramelessWindow, colorStr string) error {
+	// Not implemented (yet)
+	return nil
 }

--- a/editor/editor_darwin.go
+++ b/editor/editor_darwin.go
@@ -28,7 +28,7 @@ func setMyApplicationDelegate() {
 	C.SetMyApplicationDelegate()
 }
 
-func setNativeTitleBarColor(window *frameless.QFramelessWindow, colorStr string) error {
+func setNativeTitlebarColor(window *frameless.QFramelessWindow, colorStr string) error {
 	// Not implemented (yet)
 	return nil
 }

--- a/editor/editor_unix.go
+++ b/editor/editor_unix.go
@@ -3,10 +3,24 @@
 
 package editor
 
-import "C"
+import (
+	"C"
+
+	frameless "github.com/akiyosi/goqtframelesswindow"
+)
 
 func GetOpeningFilepath(str *C.char) {
 }
 
 func setMyApplicationDelegate() {
+}
+
+func setNativeTitleBarColor(window *frameless.QFramelessWindow, colorStr string) error {
+	// Not implemented (yet)
+	return nil
+}
+
+func setNativeTitleTextColor(window *frameless.QFramelessWindow, colorStr string) error {
+	// Not implemented (yet)
+	return nil
 }

--- a/editor/editor_unix.go
+++ b/editor/editor_unix.go
@@ -15,7 +15,7 @@ func GetOpeningFilepath(str *C.char) {
 func setMyApplicationDelegate() {
 }
 
-func setNativeTitleBarColor(window *frameless.QFramelessWindow, colorStr string) error {
+func setNativeTitlebarColor(window *frameless.QFramelessWindow, colorStr string) error {
 	// Not implemented (yet)
 	return nil
 }

--- a/editor/editor_windows.go
+++ b/editor/editor_windows.go
@@ -52,7 +52,7 @@ func checkWindowsVersion() bool {
 	return false
 }
 
-func setNativeTitleBarColor(window *frameless.QFramelessWindow, colorStr string) error {
+func setNativeTitlebarColor(window *frameless.QFramelessWindow, colorStr string) error {
 	if !checkWindowsVersion() {
 		return fmt.Errorf("unsupported Windows version")
 	}

--- a/editor/editor_windows.go
+++ b/editor/editor_windows.go
@@ -1,9 +1,137 @@
 package editor
 
-import "C"
+import (
+	"C"
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	frameless "github.com/akiyosi/goqtframelesswindow"
+)
+
+var (
+	dwmapi                = syscall.NewLazyDLL("dwmapi.dll")
+	dwmSetWindowAttribute = dwmapi.NewProc("DwmSetWindowAttribute")
+)
+
+const (
+	DWMWA_CAPTION_COLOR = 35
+	DWMWA_TEXT_COLOR    = 36
+)
 
 func GetOpeningFilepath(str *C.char) {
 }
 
 func setMyApplicationDelegate() {
+}
+
+func checkWindowsVersion() bool {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	getVersionEx := kernel32.NewProc("GetVersionExW")
+
+	type OSVERSIONINFO struct {
+		OSVersionInfoSize uint32
+		MajorVersion      uint32
+		MinorVersion      uint32
+		BuildNumber       uint32
+		PlatformId        uint32
+		CSDVersion        [128]uint16
+	}
+
+	var osvi OSVERSIONINFO
+	osvi.OSVersionInfoSize = uint32(unsafe.Sizeof(osvi))
+
+	ret, _, _ := getVersionEx.Call(uintptr(unsafe.Pointer(&osvi)))
+	if ret != 0 {
+		// Windows 11 Build 22000 or later supports title bar customization
+		return osvi.BuildNumber >= 22000
+	}
+
+	return false
+}
+
+func setNativeTitleBarColor(window *frameless.QFramelessWindow, colorStr string) error {
+	if !checkWindowsVersion() {
+		return fmt.Errorf("unsupported Windows version")
+	}
+
+	color, err := parseColor(colorStr)
+	if err != nil {
+		return err
+	}
+
+	hwnd := window.WindowWidget.Window().EffectiveWinId()
+
+	ret, _, _ := dwmSetWindowAttribute.Call(
+		hwnd,
+		DWMWA_CAPTION_COLOR,
+		uintptr(unsafe.Pointer(&color)),
+		unsafe.Sizeof(color),
+	)
+
+	if ret != 0 {
+		return syscall.Errno(ret)
+	}
+
+	return nil
+}
+
+func setNativeTitleTextColor(window *frameless.QFramelessWindow, colorStr string) error {
+	if !checkWindowsVersion() {
+		return fmt.Errorf("unsupported Windows version")
+	}
+
+	color, err := parseColor(colorStr)
+	if err != nil {
+		return err
+	}
+
+	hwnd := window.WindowWidget.Window().EffectiveWinId()
+
+	ret, _, _ := dwmSetWindowAttribute.Call(
+		hwnd,
+		DWMWA_TEXT_COLOR,
+		uintptr(unsafe.Pointer(&color)),
+		unsafe.Sizeof(color),
+	)
+
+	if ret != 0 {
+		return syscall.Errno(ret)
+	}
+
+	return nil
+}
+
+func parseColor(colorStr string) (uint32, error) {
+	if colorStr == "" {
+		return 0, nil
+	}
+
+	colorStr = strings.TrimPrefix(colorStr, "#")
+
+	var r, g, b uint64 = 0, 0, 0
+	var err error
+
+	switch len(colorStr) {
+	case 6: // RGB
+		r, err = strconv.ParseUint(colorStr[0:2], 16, 8)
+		if err != nil {
+			return 0, err
+		}
+		g, err = strconv.ParseUint(colorStr[2:4], 16, 8)
+		if err != nil {
+			return 0, err
+		}
+		b, err = strconv.ParseUint(colorStr[4:6], 16, 8)
+		if err != nil {
+			return 0, err
+		}
+	default:
+		return 0, syscall.EINVAL
+	}
+
+	// Convert to Windows COLORREF format
+	return uint32(b<<16 | g<<8 | r), nil
 }

--- a/runtime/doc/goneovim.txt
+++ b/runtime/doc/goneovim.txt
@@ -366,10 +366,10 @@ All Options are follows:
         ## Windows title bar customization (Windows 11+ only)
         ## Sets the background color of the window title bar.
         ## Use hex color format: "#RRGGBB"
-        # NativeTitleBarBackgroundColor = ""
+        # NativeTitlebarBackgroundColor = ""
         ## Sets the color of the window title text.
         ## Use hex color format: "#RRGGBB"
-        # NativeTitleBarTextColor = ""
+        # NativeTitlebarTextColor = ""
         
         ## EnableBackgroundBlur applies a translucent Blur/Acrylic effect to the window
         ## background.

--- a/runtime/doc/goneovim.txt
+++ b/runtime/doc/goneovim.txt
@@ -363,6 +363,14 @@ All Options are follows:
         ## window setting is enabled.
         # HideTitlebar = false
         
+        ## Windows title bar customization (Windows 11+ only)
+        ## Sets the background color of the window title bar.
+        ## Use hex color format: "#RRGGBB"
+        # NativeTitleBarBackgroundColor = ""
+        ## Sets the color of the window title text.
+        ## Use hex color format: "#RRGGBB"
+        # NativeTitleBarTextColor = ""
+        
         ## EnableBackgroundBlur applies a translucent Blur/Acrylic effect to the window
         ## background.
         EnableBackgroundBlur = false


### PR DESCRIPTION
Adds new configurations: `NativeTitleBarBackgroundColor`, `NativeTitleBarTextColor`.
Now goneovim can have titlebar of any color! This is dark one.

<img width="794" height="628" alt="image" src="https://github.com/user-attachments/assets/1a22aa77-fa0f-4d52-ae18-2f7c82c2092a" />

Windows only.

Close #609.