### PR TITLE
Add GonvimFocus command to activate and raise the main window

### DIFF
--- a/editor/config.go
+++ b/editor/config.go
@@ -89,8 +89,8 @@ type editorConfig struct {
 	IgnoreSaveConfirmationWithCloseButton   bool
 	UseWSL                                  bool
 	ShowDiffDialogOnDrop                    bool
-	NativeTitlebarBackgroundColor                    string
-	NativeTitlebarTextColor                          string
+	NativeTitlebarBackgroundColor           string
+	NativeTitlebarTextColor                 string
 }
 
 type cursorConfig struct {

--- a/editor/nvim.go
+++ b/editor/nvim.go
@@ -467,6 +467,7 @@ func setupGoneovimCommands(neovim *nvim.Nvim) {
 	command! GonvimSmoothScroll call rpcnotify(g:goneovim_channel_id, "Gui", "gonvim_smoothscroll")
 	command! GonvimSmoothCursor call rpcnotify(g:goneovim_channel_id, "Gui", "gonvim_smoothcursor")
 	command! GonvimIndentguide call rpcnotify(g:goneovim_channel_id, "Gui", "gonvim_indentguide")
+	command! GonvimFocus call rpcnotify(g:goneovim_channel_id, "Gui", "gonvim_activate_win")
 	command! -nargs=? GonvimMousescrollUnit call rpcnotify(g:goneovim_channel_id, "Gui", "gonvim_mousescroll_unit", <args>)
 	`
 	registerScripts := fmt.Sprintf(`call execute(%s)`, util.SplitVimscript(gonvimCommands))

--- a/editor/workspace.go
+++ b/editor/workspace.go
@@ -1936,6 +1936,8 @@ func (ws *Workspace) handleGui(updates []interface{}) {
 		ws.toggleLigatures()
 	case "gonvim_mousescroll_unit":
 		ws.setMousescrollUnit(updates[1].(string))
+	case "gonvim_activate_win":
+		editor.focusWindow()
 	case "Font":
 		ws.guiFont(updates[1].(string))
 	case "Linespace":


### PR DESCRIPTION
This PR introduces the `GonvimFocus` command to bring the goneovim main window to the foreground.
It ensures that the window is shown, raised, and requested to take focus, even if minimized or inactive.

Related to #610 